### PR TITLE
update README.md

### DIFF
--- a/Blockchain/Job-Boards/README.md
+++ b/Blockchain/Job-Boards/README.md
@@ -10,7 +10,7 @@
 - [BlockAce](https://blockace.io/)
 - [Ethlance](https://ethlance.com/)
 - [Indeed](https://www.indeed.com/jobs?q=blockchain%20developer)
-- [Glassdoor](https://www.indeed.com/jobs?q=blockchain%20developer)
+- [Glassdoor](https://www.glassdoor.com/Job/blockchain-developer-jobs-SRCH_KO0,20.htm)
 - [Arc.dev](https://arc.dev/remote-jobs?categories=Blockchain)
 - [Web3.career](https://web3.career/)
 - [UseWeb3](https://www.useweb3.xyz/jobs)


### PR DESCRIPTION
fix: glassdoor link for black chain developer leads to glassdoor instead of indeed

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

Closes #617

<!-- Example: Closes #61 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->

Changed the link from indeed to glass door
